### PR TITLE
Unified documentation style

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+---
+name: Deploy Docs
+on:
+  release:
+    types:
+    - created
+  repository_dispatch:
+    types:
+    - build-docs
+
+jobs:
+  build-linux:
+    runs-on: head
+    name: Deploy Docs
+    steps:
+      - name: Fetch gh-pages
+        uses: actions/checkout@v2
+        with:
+          path: gh-pages
+          ref: gh-pages
+      - name: Fetch source
+        uses: actions/checkout@v2
+        with:
+          path: source
+      - name: clear
+        run: rm -fr gh-pages/docs/*
+      - name: build
+        run: |
+          eval "$(/export/jgonzale/github-workflows/miniconda3-shiny/bin/conda shell.bash hook)"
+          conda activate ska3-masters
+          mkdir -p _static
+          make html
+        working-directory: source/docs
+        env:
+          PYTHONPATH: ${{ github.workspace }}/source
+          GITHUB_API_TOKEN: ${{ secrets.CHANDRA_XRAY_TOKEN }}
+      - name: copy
+        run: cp -fr source/docs/_build/html/* gh-pages/docs
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v4
+        with:
+          ref: "gh-pages"
+          cwd: "gh-pages"
+          author_name: Javier Gonzalez
+          author_email: javierggt@yahoo.com
+          message: "Deploy docs"
+          add: "docs"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,12 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-# html_theme = 'alabaster'
+html_theme = 'bootstrap-ska'
+html_theme_options = {
+logotext1: 'Ska!' ,
+logotext2: 'Ska',
+logotext3: '.File',
+}
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,9 @@ html_theme_options = {
     'logotext1': 'Ska!' ,
     'logotext2': 'Ska',
     'logotext3': '.File',
+    'homepage_url': 'https://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc',
+    'homepage_text': 'ska',
+    'homepage_text_2': 'tools'
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,9 +114,9 @@ todo_include_todos = False
 # a list of builtin themes.
 html_theme = 'bootstrap-ska'
 html_theme_options = {
-logotext1: 'Ska!' ,
-logotext2: 'Ska',
-logotext3: '.File',
+    'logotext1': 'Ska!' ,
+    'logotext2': 'Ska',
+    'logotext3': '.File',
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Ska.File's documentation!
-====================================
+Ska.File
+========
 
 .. toctree::
    :maxdepth: 2
@@ -14,12 +14,4 @@ API docs
 
 .. automodule:: Ska.File
    :members:
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
 


### PR DESCRIPTION
This PR changes the documentation to unify style among all ska packages. Documentation is always in the docs directory, with configuration in conf.py, and uses the ska theme.